### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_deploy.yaml
+++ b/.github/workflows/docker_deploy.yaml
@@ -57,7 +57,7 @@ jobs:
           echo "steps.vars.outputs.docker_file:" ${{ steps.vars.outputs.docker_file }}
 
       - name: Publish Docker Github Action
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: .
           name: unfoldingword/door43_job_handler


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore